### PR TITLE
Handle when connection close

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -265,6 +265,13 @@ export class Fetch {
       log(this, options, 'data received ' + data.length + ' bytes chunk');
       result.body += data;
     });
+    response.on('close', () => {
+      if (result.resolve) {
+        log(this, options, 'resolve with ' + result.status);
+        delete result.resolve;
+        res(result);
+      }
+    });
     response.on('end', () => {
       if (result.resolve) {
         log(this, options, 'resolve with ' + result.status);


### PR DESCRIPTION
Handle when connection close by
If response ready tobe resolve, but the connection was closed and on('end') event was not fired, then just resolve the response in on('close') event.